### PR TITLE
Fix broken devcontainer build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
 		"ghcr.io/devcontainers/features/git:1": {
 			"version": "latest"
 		},
-		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/go:1": {},
 		"ghcr.io/eitsupi/devcontainer-features/go-task:0": {},
 		"ghcr.io/guiyomh/features/golangci-lint:0": {},


### PR DESCRIPTION
So there's something weird going on with the whole feature thing. For example this github-cli feature _can_ depend on Git on e.g. debian: it tries to install a manually downloaded github-cli deb package which fails if git is not installed. An "official" git feature exists, but the github-cli feature does not depend on it for whatever reason.

There is this `overrideFeatureInstallOrder` property that's supposed to be available but a) my vs code does a yellow squiggly on that and b) it doesn't seem to do anything. It's mentioned here: https://code.visualstudio.com/blogs/2022/09/15/dev-container-features#_feature-installation-order. I also opened a PR on the features repo: https://github.com/devcontainers/features/pull/301

Anyway this PR just drops the github-cli feature. Doing this fixes the immediate issue of not being able to build the container.