### PR TITLE
Refactor command initialization

### DIFF
--- a/cmd/cmds_test.go
+++ b/cmd/cmds_test.go
@@ -80,7 +80,9 @@ func iExecuteRecipe(ctx context.Context, recipe string) (context.Context, error)
 		return ctx, err
 	}
 
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		return ctx, err
+	}
 
 	ctx = context.WithValue(ctx, cmdStdOutCtxKey{}, cmdStdOut.String())
 	ctx = context.WithValue(ctx, cmdStdErrCtxKey{}, cmdStdErr.String())
@@ -149,7 +151,10 @@ func iUpgradeRecipe(ctx context.Context, recipe string) (context.Context, error)
 	cmd, cmdStdOut, cmdStdErr := WrapCmdOutputs(newUpgradeCmd)
 
 	cmd.SetArgs([]string{projectDir, filepath.Join(recipesDir, recipe)})
-	cmd.Execute()
+
+	if err := cmd.Execute(); err != nil {
+		return ctx, err
+	}
 
 	ctx = context.WithValue(ctx, cmdStdOutCtxKey{}, cmdStdOut.String())
 	ctx = context.WithValue(ctx, cmdStdErrCtxKey{}, cmdStdErr.String())

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -36,7 +36,9 @@ func newCreateCmd() *cobra.Command {
 		},
 	}
 
-	option.ApplyFlags(&opts, cmd.Flags())
+	if err := option.ApplyFlags(&opts, cmd.Flags()); err != nil {
+		return nil
+	}
 
 	return cmd
 }

--- a/cmd/eject.go
+++ b/cmd/eject.go
@@ -33,7 +33,9 @@ func newEjectCmd() *cobra.Command {
 		},
 	}
 
-	option.ApplyFlags(&opts, cmd.Flags())
+	if err := option.ApplyFlags(&opts, cmd.Flags()); err != nil {
+		return nil
+	}
 
 	return cmd
 }

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -33,7 +33,9 @@ func newExecuteCmd() *cobra.Command {
 		},
 	}
 
-	option.ApplyFlags(&opts, cmd.Flags())
+	if err := option.ApplyFlags(&opts, cmd.Flags()); err != nil {
+		return nil
+	}
 
 	return cmd
 }

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -3,40 +3,50 @@ package main
 import (
 	"os"
 
+	"github.com/futurice/jalapeno/internal/option"
 	"github.com/futurice/jalapeno/pkg/engine"
 	"github.com/futurice/jalapeno/pkg/recipe"
 	"github.com/futurice/jalapeno/pkg/recipeutil"
 	"github.com/spf13/cobra"
 )
 
-var (
-	outputBasePath = ""
-)
+type executeOptions struct {
+	RecipePath string
+	option.Output
+	option.Common
+}
 
 func newExecuteCmd() *cobra.Command {
-	var execCmd = &cobra.Command{
+	var opts executeOptions
+	var cmd = &cobra.Command{
 		Use:     "execute RECIPE",
 		Aliases: []string{"exec", "e"},
 		Short:   "Execute a given recipe and save output to path",
 		Long:    "", // TODO
 		Args:    cobra.ExactArgs(1),
-		Run:     executeFunc,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.RecipePath = args[0]
+			return option.Parse(&opts)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runExecute(cmd, opts)
+		},
 	}
 
-	execCmd.Flags().StringVarP(&outputBasePath, "output", "o", ".", "Path where the output files should be created")
+	option.ApplyFlags(&opts, cmd.Flags())
 
-	return execCmd
+	return cmd
 }
 
-func executeFunc(cmd *cobra.Command, args []string) {
-	if _, err := os.Stat(outputBasePath); os.IsNotExist(err) {
-		cmd.PrintErrln("Error: output path does not exist")
+func runExecute(cmd *cobra.Command, opts executeOptions) {
+	if _, err := os.Stat(opts.OutputPath); os.IsNotExist(err) {
+		cmd.PrintErrln("output path does not exist")
 		return
 	}
 
-	re, err := recipe.Load(args[0])
+	re, err := recipe.Load(opts.RecipePath)
 	if err != nil {
-		cmd.PrintErrf("Error: can't load the recipe: %s\n", err)
+		cmd.PrintErrf("can't load the recipe: %v\n", err)
 		return
 	}
 
@@ -48,12 +58,12 @@ func executeFunc(cmd *cobra.Command, args []string) {
 
 	err = re.Validate()
 	if err != nil {
-		cmd.PrintErrf("Error: the provided recipe was invalid: %s\n", err)
+		cmd.PrintErrf("the provided recipe was invalid: %v\n", err)
 		return
 	}
 
 	if len(re.Templates) == 0 {
-		cmd.PrintErrf("Error: the recipe does not contain any templates")
+		cmd.PrintErrf("the recipe does not contain any templates\n")
 		return
 	}
 
@@ -61,7 +71,7 @@ func executeFunc(cmd *cobra.Command, args []string) {
 
 	err = recipeutil.PromptUserForValues(re)
 	if err != nil {
-		cmd.PrintErrf("Error when prompting for values: %s\n", err)
+		cmd.PrintErrf("error when prompting for values: %v\n", err)
 		return
 	}
 
@@ -72,7 +82,7 @@ func executeFunc(cmd *cobra.Command, args []string) {
 	}
 
 	// Load all rendered recipes
-	rendered, err := recipe.LoadRendered(outputBasePath)
+	rendered, err := recipe.LoadRendered(opts.OutputPath)
 	if err != nil {
 		cmd.PrintErrln(err)
 		return
@@ -87,13 +97,13 @@ func executeFunc(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	err = re.Save(outputBasePath)
+	err = re.Save(opts.OutputPath)
 	if err != nil {
 		cmd.PrintErrln(err)
 		return
 	}
 
-	err = recipeutil.SaveFiles(re.Files, outputBasePath)
+	err = recipeutil.SaveFiles(re.Files, opts.OutputPath)
 	if err != nil {
 		cmd.PrintErrln(err)
 		return

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -39,7 +39,9 @@ func newUpgradeCmd() *cobra.Command {
 		},
 	}
 
-	option.ApplyFlags(&opts, cmd.Flags())
+	if err := option.ApplyFlags(&opts, cmd.Flags()); err != nil {
+		return nil
+	}
 
 	return cmd
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/futurice/jalapeno/internal/option"
 	"github.com/futurice/jalapeno/pkg/engine"
 	"github.com/futurice/jalapeno/pkg/recipe"
 	"github.com/futurice/jalapeno/pkg/recipeutil"
@@ -15,30 +16,42 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+type upgradeOptions struct {
+	TargetPath string
+	SourcePath string
+	option.Common
+}
+
 func newUpgradeCmd() *cobra.Command {
-	// upgradeCmd represents the upgrade command
-	var upgradeCmd = &cobra.Command{
+	var opts upgradeOptions
+	var cmd = &cobra.Command{
 		Use:   "upgrade PROJECT RECIPE",
 		Short: "Upgrade recipe in a project",
 		Long:  "", // TODO
-		Run:   upgradeFunc,
 		Args:  cobra.ExactArgs(2),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.TargetPath = args[0]
+			opts.SourcePath = args[1]
+			return option.Parse(&opts)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runUpgrade(cmd, opts)
+		},
 	}
 
-	return upgradeCmd
+	option.ApplyFlags(&opts, cmd.Flags())
+
+	return cmd
 }
 
-func upgradeFunc(cmd *cobra.Command, args []string) {
-	target := args[0]
-	source := args[1]
-
-	re, err := recipe.Load(source)
+func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
+	re, err := recipe.Load(opts.SourcePath)
 	if err != nil {
 		cmd.PrintErrln(err)
 		return
 	}
 
-	rendered, err := recipe.LoadRendered(target)
+	rendered, err := recipe.LoadRendered(opts.TargetPath)
 	if err != nil {
 		cmd.PrintErrln(err)
 		return
@@ -51,7 +64,7 @@ func upgradeFunc(cmd *cobra.Command, args []string) {
 		}
 	}
 	if prevRe == nil {
-		cmd.PrintErrf("directory %s does not contain recipe %s\n", target, re.Name)
+		cmd.PrintErrf("directory %s does not contain recipe %s\n", opts.TargetPath, re.Name)
 		return
 	}
 
@@ -90,22 +103,21 @@ func upgradeFunc(cmd *cobra.Command, args []string) {
 	err = recipeutil.PromptUserForValues(re)
 	if err != nil {
 		cmd.PrintErrln(err)
-		return
 	}
 
 	err = re.Render(engine.Engine{})
 	if err != nil {
-		cmd.PrintErrln(err)
 		return
 	}
 
 	// read common ignore file if it exists
 	ignorePatterns := make([]string, 0)
-	if data, err := os.ReadFile(filepath.Join(target, recipe.IgnoreFileName)); err == nil {
+	if data, err := os.ReadFile(filepath.Join(opts.TargetPath, recipe.IgnoreFileName)); err == nil {
 		ignorePatterns = append(ignorePatterns, strings.Split(string(data), "\n")...)
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		// something else happened than trying to read an ignore file that does not exist
-		cmd.PrintErrln("failed to read ignore file", err)
+		cmd.PrintErrf("failed to read ignore file: %v\n", err)
+		return
 	}
 	ignorePatterns = append(ignorePatterns, re.IgnorePatterns...)
 
@@ -117,7 +129,8 @@ func upgradeFunc(cmd *cobra.Command, args []string) {
 		skip := false
 		for _, pattern := range ignorePatterns {
 			if matched, err := filepath.Match(pattern, path); err != nil {
-				cmd.PrintErrln("bad ignore pattern", pattern, err)
+				cmd.PrintErrf("bad ignore pattern '%s': %v\n", pattern, err)
+				return
 			} else if matched {
 				// file was marked as ignored for upgrades
 				skip = true
@@ -130,8 +143,9 @@ func upgradeFunc(cmd *cobra.Command, args []string) {
 
 		if prevFile, exists := prevRe.Files[path]; exists {
 			// Check if file was modified after rendering
-			if modified, err := recipeutil.IsFileModified(target, path, prevFile); err != nil {
+			if modified, err := recipeutil.IsFileModified(opts.TargetPath, path, prevFile); err != nil {
 				cmd.PrintErrln(err)
+				return
 			} else if modified {
 				// The file contents has been modified
 				if !overrideNoticed {
@@ -163,13 +177,13 @@ func upgradeFunc(cmd *cobra.Command, args []string) {
 		output[path] = re.Files[path]
 	}
 
-	err = recipeutil.SaveFiles(output, target)
+	err = recipeutil.SaveFiles(output, opts.TargetPath)
 	if err != nil {
 		cmd.PrintErrln(err)
 		return
 	}
 
-	err = re.Save(target)
+	err = re.Save(opts.TargetPath)
 	if err != nil {
 		cmd.PrintErrln(err)
 		return

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,33 +1,46 @@
 package main
 
 import (
+	"github.com/futurice/jalapeno/internal/option"
 	"github.com/futurice/jalapeno/pkg/recipe"
 	"github.com/spf13/cobra"
 )
 
+type validateOptions struct {
+	TargetPath string
+	option.Common
+}
+
 func newValidateCmd() *cobra.Command {
-	var validateCmd = &cobra.Command{
+	var opts validateOptions
+	var cmd = &cobra.Command{
 		Use:   "validate RECIPE",
 		Short: "Validate a recipe",
 		Long:  "", // TODO
-		Run:   validateFunc,
-		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.TargetPath = args[0]
+			return option.Parse(&opts)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runValidate(cmd, opts)
+		},
+		Args: cobra.ExactArgs(1),
 	}
 
-	return validateCmd
+	option.ApplyFlags(&opts, cmd.Flags())
+
+	return cmd
 }
 
-func validateFunc(cmd *cobra.Command, args []string) {
-	r, err := recipe.Load(args[0])
+func runValidate(cmd *cobra.Command, opts validateOptions) {
+	r, err := recipe.Load(opts.TargetPath)
 	if err != nil {
-		cmd.PrintErrf("could not load the recipe: %s\n", err)
-		return
+		cmd.PrintErrf("could not load the recipe: %v\n", err)
 	}
 
 	err = r.Validate()
 	if err != nil {
-		cmd.PrintErrf("validation failed: %s\n", err)
-		return
+		cmd.PrintErrf("validation failed: %v\n", err)
 	}
 
 	cmd.Println("Validation ok")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -27,7 +27,9 @@ func newValidateCmd() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 	}
 
-	option.ApplyFlags(&opts, cmd.Flags())
+	if err := option.ApplyFlags(&opts, cmd.Flags()); err != nil {
+		return nil
+	}
 
 	return cmd
 }

--- a/internal/option/applier.go
+++ b/internal/option/applier.go
@@ -26,8 +26,8 @@ type FlagApplier interface {
 // target flag set.
 // NOTE: The option argument need to be a pointer to the options, so its value
 // becomes addressable.
-func ApplyFlags(optsPtr interface{}, target *pflag.FlagSet) {
-	rangeFields(optsPtr, func(fa FlagApplier) error {
+func ApplyFlags(optsPtr interface{}, target *pflag.FlagSet) error {
+	return rangeFields(optsPtr, func(fa FlagApplier) error {
 		fa.ApplyFlags(target)
 		return nil
 	})

--- a/internal/option/applier.go
+++ b/internal/option/applier.go
@@ -1,0 +1,34 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// FlagApplier applies flags to a command flag set.
+type FlagApplier interface {
+	ApplyFlags(*pflag.FlagSet)
+}
+
+// ApplyFlags applies applicable fields of the passed-in option pointer to the
+// target flag set.
+// NOTE: The option argument need to be a pointer to the options, so its value
+// becomes addressable.
+func ApplyFlags(optsPtr interface{}, target *pflag.FlagSet) {
+	rangeFields(optsPtr, func(fa FlagApplier) error {
+		fa.ApplyFlags(target)
+		return nil
+	})
+}

--- a/internal/option/common.go
+++ b/internal/option/common.go
@@ -1,0 +1,13 @@
+package option
+
+import "github.com/spf13/pflag"
+
+type Common struct {
+	Debug   bool
+	Verbose bool
+}
+
+func (opts *Common) ApplyFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&opts.Debug, "debug", "d", false, "debug mode")
+	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "verbose output")
+}

--- a/internal/option/output.go
+++ b/internal/option/output.go
@@ -1,0 +1,11 @@
+package option
+
+import "github.com/spf13/pflag"
+
+type Output struct {
+	OutputPath string
+}
+
+func (opts *Output) ApplyFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&opts.OutputPath, "output", "o", ".", "path where the output files should be created")
+}

--- a/internal/option/parser.go
+++ b/internal/option/parser.go
@@ -1,0 +1,51 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"reflect"
+)
+
+// FlagParser parses flags in an option.
+type FlagParser interface {
+	Parse() error
+}
+
+// Parse parses applicable fields of the passed-in option pointer and returns
+// error during parsing.
+func Parse(optsPtr interface{}) error {
+	return rangeFields(optsPtr, func(fp FlagParser) error {
+		return fp.Parse()
+	})
+}
+
+// rangeFields goes through all fields of ptr, optionally run fn if a field is
+// public AND typed T.
+func rangeFields[T any](ptr any, fn func(T) error) error {
+	v := reflect.ValueOf(ptr).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.CanSet() {
+			iface := f.Addr().Interface()
+			if opts, ok := iface.(T); ok {
+				if err := fn(opts); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- Use `option` structs to define options for each command instead of having global variables to save the arguments to
- Refactor tests to utilize `cmd.SetOut` and `cmd.SetErr`