### PR TITLE
Add generates prop to build task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,6 +27,8 @@ tasks:
     desc: Build the CLI
     sources:
       - "./**/*.go"
+    generates:
+      - "bin/jalapeno"
     cmds:
       - go build -o bin/jalapeno {{.ENTRYPOINT}}
   debug:


### PR DESCRIPTION
This makes task build the binary if it is missing even if the source files have not changed.