### PR TITLE
Split rendered recipe to "sauce" concept

### DIFF
--- a/cmd/cmds_test.go
+++ b/cmd/cmds_test.go
@@ -9,8 +9,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -325,17 +327,23 @@ func createLocalRegistry(opts *dockertest.RunOptions) (*dockertest.Resource, err
 
 	host := resource.GetHostPort("5000/tcp")
 
-	pool.MaxWait = 30 * time.Second
+	pool.MaxWait = 10 * time.Second
 	if err = pool.Retry(func() error {
-		_, err := pool.Client.HTTPClient.Get(fmt.Sprintf("http://%s/v2/", host))
-		return err
+		url := fmt.Sprintf("http://%s/v2/", host)
+		resp, err := http.Get(url)
+		if err != nil {
+			return err
+		}
+
+		// Non-authenticated registry responds with status 200, authenticated with 400
+		if resp.StatusCode == 200 || resp.StatusCode == 400 {
+			return nil
+		}
+
+		return errors.New("endpoint not yet healthy")
 	}); err != nil {
 		return nil, fmt.Errorf("could not connect to docker: %s", err)
 	}
-
-	// Even though we check if the registry is ready, running tests immediately causes EOF errors to happen.
-	// So we need to wait a bit more to registry to be ready.
-	time.Sleep(200 * time.Millisecond)
 
 	err = resource.Expire(60) // If the cleanup fails, this will stop the container eventually
 	if err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -82,18 +82,16 @@ func runCreate(cmd *cobra.Command, opts createOptions) {
 }
 
 func createExampleRecipe(name string) *recipe.Recipe {
-	return &recipe.Recipe{
-		Metadata: recipe.Metadata{
-			APIVersion:  "v1",
-			Name:        name,
-			Version:     "v0.0.0",
-			Description: "Description about what the recipe is used for and what it contains. For example tech stack, cloud environments, tools",
-		},
-		Variables: []recipe.Variable{
-			{Name: "MY_VAR", Default: "Hello World!"},
-		},
-		Templates: map[string][]byte{
-			"README.md": []byte("{{ .Variables.MY_VAR }}"),
-		},
+	r := recipe.NewRecipe()
+	r.Metadata.Name = name
+	r.Metadata.Version = "v0.0.0"
+	r.Metadata.Description = "Description about what the recipe is used for and what it contains. For example tech stack, cloud environments, tools"
+	r.Variables = []recipe.Variable{
+		{Name: "MY_VAR", Default: "Hello World!"},
 	}
+	r.Templates = map[string][]byte{
+		"README.md": []byte("{{ .Variables.MY_VAR }}"),
+	}
+
+	return r
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/futurice/jalapeno/cmd/internal/option"
 	"github.com/futurice/jalapeno/pkg/recipe"
 	"github.com/spf13/cobra"
@@ -25,6 +22,7 @@ func newCreateCmd() *cobra.Command {
 	foo/
 	├── recipe.yml
 	├── templates/
+	├──── README.md
 `, // TODO
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -46,37 +44,15 @@ func newCreateCmd() *cobra.Command {
 func runCreate(cmd *cobra.Command, opts createOptions) {
 	re := createExampleRecipe(opts.RecipeName)
 
-	path := filepath.Join(".", opts.RecipeName)
-
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		cmd.PrintErrf("directory '%s' already exists\n", opts.RecipeName)
+	err := re.Validate()
+	if err != nil {
+		cmd.PrintErrln("Internal error: placeholder recipe is not valid")
 		return
 	}
 
-	err := os.Mkdir(path, 0700)
+	err = re.Save(".")
 	if err != nil {
-		cmd.PrintErrf("can not create directory %s: %v\n", path, err)
-		return
-	}
-
-	err = re.Validate()
-	if err != nil {
-		// TODO: Clean up the already create directory if the command failed
-		cmd.PrintErrln("internal error: placeholder recipe is not valid")
-		return
-	}
-
-	err = re.Save(path)
-	if err != nil {
-		// TODO: Clean up the already create directory if the command failed
-		cmd.PrintErrf("can not save recipe to the directory: %v\n", err)
-		return
-	}
-
-	err = os.Mkdir(filepath.Join(path, recipe.RecipeTemplatesDirName), 0700)
-	if err != nil {
-		// TODO: Clean up the already create directory if the command failed
-		cmd.PrintErrf("can not save templates to the directory: %v\n", err)
+		cmd.PrintErrf("Error: can not save recipe to the directory: %v\n", err)
 		return
 	}
 }

--- a/cmd/eject.go
+++ b/cmd/eject.go
@@ -46,7 +46,7 @@ func runEject(cmd *cobra.Command, opts ejectOptions) {
 		return
 	}
 
-	jalapenoPath := filepath.Join(opts.ProjectPath, recipe.RenderedRecipeDirName)
+	jalapenoPath := filepath.Join(opts.ProjectPath, recipe.SauceDirName)
 
 	if stat, err := os.Stat(jalapenoPath); os.IsNotExist(err) || !stat.IsDir() {
 		cmd.PrintErrf("'%s' is not a Jalapeno project\n", opts.ProjectPath)
@@ -56,7 +56,7 @@ func runEject(cmd *cobra.Command, opts ejectOptions) {
 	cmd.Printf("Deleting %s...", jalapenoPath)
 	err := os.RemoveAll(jalapenoPath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -72,7 +72,7 @@ func runExecute(cmd *cobra.Command, opts executeOptions) {
 	}
 
 	// Load all existingSauces recipes
-	existingSauces, err := recipe.LoadSauce(opts.OutputPath)
+	existingSauces, err := recipe.LoadSauces(opts.OutputPath)
 	if err != nil {
 		cmd.PrintErrf("Error: %s", err)
 		return

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -45,7 +45,7 @@ func runExecute(cmd *cobra.Command, opts executeOptions) {
 		return
 	}
 
-	re, err := recipe.Load(opts.RecipePath)
+	re, err := recipe.LoadRecipe(opts.RecipePath)
 	if err != nil {
 		cmd.PrintErrf("can't load the recipe: %v\n", err)
 		return
@@ -59,43 +59,43 @@ func runExecute(cmd *cobra.Command, opts executeOptions) {
 
 	// TODO: Set values provided by --set flag to re.Values
 
-	err = recipeutil.PromptUserForValues(re)
+	values, err := recipeutil.PromptUserForValues(re.Variables)
 	if err != nil {
-		cmd.PrintErrf("error when prompting for values: %v\n", err)
+		cmd.PrintErrf("Error when prompting for values: %v\n", err)
 		return
 	}
 
-	err = re.Render()
+	sauce, err := re.Execute(values)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
-	// Load all rendered recipes
-	rendered, err := recipe.LoadRendered(opts.OutputPath)
+	// Load all existingSauces recipes
+	existingSauces, err := recipe.LoadSauce(opts.OutputPath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
 	// Check for conflicts
-	for _, r := range rendered {
-		conflicts := re.Conflicts(r)
+	for _, s := range existingSauces {
+		conflicts := s.Conflicts(sauce)
 		if conflicts != nil {
-			cmd.PrintErrf("conflict in recipe %s: %s was already created by recipe %s\n", re.Name, conflicts[0].Path, r.Name)
+			cmd.PrintErrf("conflict in recipe %s: %s was already created by recipe %s\n", re.Name, conflicts[0].Path, s.Recipe.Name)
 			return
 		}
 	}
 
-	err = re.Save(opts.OutputPath)
+	err = sauce.Save(opts.OutputPath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
-	err = recipeutil.SaveFiles(re.Files, opts.OutputPath)
+	err = recipeutil.SaveFiles(sauce.Files, opts.OutputPath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -46,13 +46,13 @@ func runPull(cmd *cobra.Command, opts pullOptions) {
 
 	repo, err := opts.NewRepository(opts.TargetRef, opts.Common)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
 	dst, err := file.New(opts.OutputPath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -46,7 +46,7 @@ func newPushCmd() *cobra.Command {
 func runPush(cmd *cobra.Command, opts pushOptions) {
 	ctx := context.Background()
 
-	re, err := recipe.Load(opts.RecipePath)
+	re, err := recipe.LoadRecipe(opts.RecipePath)
 	if err != nil {
 		cmd.PrintErrf("Error: can't load the recipe: %s\n", err)
 		return
@@ -54,7 +54,7 @@ func runPush(cmd *cobra.Command, opts pushOptions) {
 
 	store, err := file.New("")
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
@@ -62,25 +62,25 @@ func runPush(cmd *cobra.Command, opts pushOptions) {
 
 	desc, err := store.Add(ctx, re.Name, "application/x.futurice.jalapeno.recipe.v1", opts.RecipePath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
 	root, err := oras.Pack(ctx, store, "", []v1.Descriptor{desc}, oras.PackOptions{PackImageManifest: true})
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
 	err = store.Tag(ctx, root, re.Version)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
 	repo, err := opts.NewRepository(opts.TargetRef, opts.Common)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -35,7 +35,7 @@ func newTestCmd() *cobra.Command {
 }
 
 func runTest(cmd *cobra.Command, opts testOptions) {
-	re, err := recipe.Load(opts.RecipePath)
+	re, err := recipe.LoadRecipe(opts.RecipePath)
 	if err != nil {
 		cmd.PrintErrf("Can't load the recipe: %v\n", err)
 		return

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -46,68 +46,67 @@ func newUpgradeCmd() *cobra.Command {
 }
 
 func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
-	re, err := recipe.Load(opts.SourcePath)
+	re, err := recipe.LoadRecipe(opts.SourcePath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
-	rendered, err := recipe.LoadRendered(opts.TargetPath)
+	sauces, err := recipe.LoadSauce(opts.TargetPath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
-	var prevRe *recipe.Recipe
-	for _, r := range rendered {
-		if r.Name == re.Name {
-			prevRe = r
+	var oldSauce *recipe.Sauce
+	for _, s := range sauces {
+		if s.Recipe.Name == re.Name {
+			oldSauce = s
 			break
 		}
 	}
-	if prevRe == nil {
-		cmd.PrintErrf("directory %s does not contain recipe %s\n", opts.TargetPath, re.Name)
+	if oldSauce == nil {
+		cmd.PrintErrf("Error: Directory %s does not contain sauce %s. Recipe name used in the project should match the recipe which is used for upgrading", opts.TargetPath, re.Name)
 		return
 	}
 
-	if !prevRe.IsExecuted() {
-		cmd.PrintErrln("the first argument should point to the project which uses the recipe")
-		return
-	}
-
-	if re.IsExecuted() {
-		cmd.PrintErrln("the second argument should point to the recipe which will be used for upgrading")
-		return
-	}
-
-	if re.Metadata.Name != prevRe.Metadata.Name {
-		cmd.PrintErrln("recipe name used in the project should match the recipe which is used for upgrading")
-		return
-	}
-
-	if semver.Compare(re.Metadata.Version, prevRe.Metadata.Version) <= 0 {
+	if semver.Compare(re.Metadata.Version, oldSauce.Recipe.Metadata.Version) <= 0 {
 		cmd.PrintErrln("new recipe version is lower or same than the existing one")
 		return
 	}
 
-	cmd.Printf("Upgrade from %s to %s\n", prevRe.Metadata.Version, re.Metadata.Version)
-
-	re.Values = prevRe.Values
+	cmd.Printf("Upgrade from %s to %s\n", oldSauce.Recipe.Metadata.Version, re.Metadata.Version)
 
 	// Check if the new version of the recipe has removed some variables
 	// which existed on previous version
-	for _, v := range re.Variables {
-		if _, exists := re.Values[v.Name]; !exists {
-			delete(re.Values, v.Name)
+	for valueName := range oldSauce.Values {
+		found := false
+		for _, variable := range re.Variables {
+			if variable.Name == valueName {
+				found = true
+			}
+		}
+		if !found {
+			delete(oldSauce.Values, valueName)
 		}
 	}
 
-	err = recipeutil.PromptUserForValues(re)
-	if err != nil {
-		cmd.PrintErrln(err)
+	// Don't prompt variables which already has a value in existing sauce
+	vars := make([]recipe.Variable, 0, len(re.Variables))
+	for _, v := range re.Variables {
+		if _, exists := oldSauce.Values[v.Name]; !exists {
+			vars = append(vars, v)
+		}
 	}
 
-	err = re.Render()
+	values, err := recipeutil.PromptUserForValues(vars)
 	if err != nil {
+		cmd.PrintErrf("Error: %s", err)
+		return
+	}
+
+	newSauce, err := re.Execute(values)
+	if err != nil {
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
@@ -123,10 +122,10 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 	ignorePatterns = append(ignorePatterns, re.IgnorePatterns...)
 
 	// Collect files which should be written to the destination directory
-	output := make(map[string]recipe.File, len(re.Files))
+	output := make(map[string]recipe.File, len(newSauce.Files))
 	overrideNoticed := false
 
-	for path := range re.Files {
+	for path := range newSauce.Files {
 		skip := false
 		for _, pattern := range ignorePatterns {
 			if matched, err := filepath.Match(pattern, path); err != nil {
@@ -142,10 +141,10 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 			continue
 		}
 
-		if prevFile, exists := prevRe.Files[path]; exists {
+		if prevFile, exists := oldSauce.Files[path]; exists {
 			// Check if file was modified after rendering
 			if modified, err := recipeutil.IsFileModified(opts.TargetPath, path, prevFile); err != nil {
-				cmd.PrintErrln(err)
+				cmd.PrintErrf("Error: %s", err)
 				return
 			} else if modified {
 				// The file contents has been modified
@@ -162,7 +161,7 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 				}
 				err = survey.AskOne(prompt, &override)
 				if err != nil {
-					cmd.PrintErrln(err)
+					cmd.PrintErrf("Error: %s", err)
 					return
 				}
 
@@ -175,18 +174,18 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 		}
 
 		// Add new file or replace existing one
-		output[path] = re.Files[path]
+		output[path] = newSauce.Files[path]
 	}
 
 	err = recipeutil.SaveFiles(output, opts.TargetPath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
-	err = re.Save(opts.TargetPath)
+	err = newSauce.Save(opts.TargetPath)
 	if err != nil {
-		cmd.PrintErrln(err)
+		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -16,8 +16,8 @@ import (
 )
 
 type upgradeOptions struct {
-	TargetPath string
-	SourcePath string
+	ProjectPath string
+	SourcePath  string
 	option.Common
 }
 
@@ -29,7 +29,7 @@ func newUpgradeCmd() *cobra.Command {
 		Long:  "", // TODO
 		Args:  cobra.ExactArgs(2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			opts.TargetPath = args[0]
+			opts.ProjectPath = args[0]
 			opts.SourcePath = args[1]
 			return option.Parse(&opts)
 		},
@@ -52,7 +52,7 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 		return
 	}
 
-	sauces, err := recipe.LoadSauce(opts.TargetPath)
+	sauces, err := recipe.LoadSauce(opts.ProjectPath)
 	if err != nil {
 		cmd.PrintErrf("Error: %s", err)
 		return
@@ -65,7 +65,7 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 		}
 	}
 	if oldSauce == nil {
-		cmd.PrintErrf("Error: Directory %s does not contain sauce %s. Recipe name used in the project should match the recipe which is used for upgrading", opts.TargetPath, re.Name)
+		cmd.PrintErrf("Error: Directory %s does not contain sauce %s. Recipe name used in the project should match the recipe which is used for upgrading", opts.ProjectPath, re.Name)
 		return
 	}
 
@@ -112,7 +112,7 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 
 	// read common ignore file if it exists
 	ignorePatterns := make([]string, 0)
-	if data, err := os.ReadFile(filepath.Join(opts.TargetPath, recipe.IgnoreFileName)); err == nil {
+	if data, err := os.ReadFile(filepath.Join(opts.ProjectPath, recipe.IgnoreFileName)); err == nil {
 		ignorePatterns = append(ignorePatterns, strings.Split(string(data), "\n")...)
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		// something else happened than trying to read an ignore file that does not exist
@@ -143,7 +143,7 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 
 		if prevFile, exists := oldSauce.Files[path]; exists {
 			// Check if file was modified after rendering
-			if modified, err := recipeutil.IsFileModified(opts.TargetPath, path, prevFile); err != nil {
+			if modified, err := recipeutil.IsFileModified(opts.ProjectPath, path, prevFile); err != nil {
 				cmd.PrintErrf("Error: %s", err)
 				return
 			} else if modified {
@@ -177,13 +177,13 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 		output[path] = newSauce.Files[path]
 	}
 
-	err = recipeutil.SaveFiles(output, opts.TargetPath)
+	err = recipeutil.SaveFiles(output, opts.ProjectPath)
 	if err != nil {
 		cmd.PrintErrf("Error: %s", err)
 		return
 	}
 
-	err = newSauce.Save(opts.TargetPath)
+	err = newSauce.Save(opts.ProjectPath)
 	if err != nil {
 		cmd.PrintErrf("Error: %s", err)
 		return

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -52,7 +52,7 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) {
 		return
 	}
 
-	sauces, err := recipe.LoadSauce(opts.ProjectPath)
+	sauces, err := recipe.LoadSauces(opts.ProjectPath)
 	if err != nil {
 		cmd.PrintErrf("Error: %s", err)
 		return

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	re "github.com/futurice/jalapeno/pkg/recipe"
 )
 
-func iUpgradeRecipe(ctx context.Context, recipe string) (context.Context, error) {
+func iUpgradeSauce(ctx context.Context, recipe string) (context.Context, error) {
 	recipesDir := ctx.Value(recipesDirectoryPathCtxKey{}).(string)
 	projectDir := ctx.Value(projectDirectoryPathCtxKey{}).(string)
 
@@ -64,7 +66,7 @@ func iChangeRecipeTemplateToRender(ctx context.Context, recipeName, filename, co
 
 func iChangeRecipeToVersion(ctx context.Context, recipeName, version string) (context.Context, error) {
 	recipesDir := ctx.Value(recipesDirectoryPathCtxKey{}).(string)
-	recipeFile := filepath.Join(recipesDir, recipeName, "recipe.yml")
+	recipeFile := filepath.Join(recipesDir, recipeName, re.RecipeFileName+re.YAMLExtension)
 	recipeData, err := os.ReadFile(recipeFile)
 	if err != nil {
 		return ctx, err
@@ -72,7 +74,7 @@ func iChangeRecipeToVersion(ctx context.Context, recipeName, version string) (co
 
 	newData := strings.Replace(string(recipeData), "v0.0.1", version, 1)
 
-	if err := os.WriteFile(filepath.Join(recipesDir, recipeName, "recipe.yml"), []byte(newData), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(recipesDir, recipeName, re.RecipeFileName+re.YAMLExtension), []byte(newData), 0644); err != nil {
 		return ctx, err
 	}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -35,7 +35,7 @@ func newValidateCmd() *cobra.Command {
 }
 
 func runValidate(cmd *cobra.Command, opts validateOptions) {
-	r, err := recipe.Load(opts.TargetPath)
+	r, err := recipe.LoadRecipe(opts.TargetPath)
 	if err != nil {
 		cmd.PrintErrf("could not load the recipe: %v\n", err)
 	}

--- a/features/execute-recipes.feature
+++ b/features/execute-recipes.feature
@@ -8,7 +8,7 @@ Feature: Execute recipes
     When I execute recipe "foo"
     Then execution of the recipe has succeeded
     And the project directory should contain file "README.md"
-    And the project directory should contain file ".jalapeno/recipe.yml" with "name: foo"
+    And the project directory should contain file ".jalapeno/sauce.yml" with "name: foo"
 
   Scenario: Execute multiple recipes
     Given a project directory
@@ -22,8 +22,8 @@ Feature: Execute recipes
     And no errors were printed
     And the project directory should contain file "README.md"
     And the project directory should contain file "Taskfile.yml"
-    And the project directory should contain file ".jalapeno/recipe.yml" with "name: foo"
-    And the project directory should contain file ".jalapeno/recipe.yml" with "name: bar"
+    And the project directory should contain file ".jalapeno/sauce.yml" with "name: foo"
+    And the project directory should contain file ".jalapeno/sauce.yml" with "name: bar"
 
   Scenario: New recipe conflicts with the previous recipe
     Given a project directory

--- a/features/execute-recipes.feature
+++ b/features/execute-recipes.feature
@@ -8,7 +8,7 @@ Feature: Execute recipes
     When I execute recipe "foo"
     Then execution of the recipe has succeeded
     And the project directory should contain file "README.md"
-    And the project directory should contain file ".jalapeno/sauce.yml" with "name: foo"
+    And the project directory should contain file ".jalapeno/sauces.yml" with "name: foo"
 
   Scenario: Execute multiple recipes
     Given a project directory
@@ -22,8 +22,8 @@ Feature: Execute recipes
     And no errors were printed
     And the project directory should contain file "README.md"
     And the project directory should contain file "Taskfile.yml"
-    And the project directory should contain file ".jalapeno/sauce.yml" with "name: foo"
-    And the project directory should contain file ".jalapeno/sauce.yml" with "name: bar"
+    And the project directory should contain file ".jalapeno/sauces.yml" with "name: foo"
+    And the project directory should contain file ".jalapeno/sauces.yml" with "name: bar"
 
   Scenario: New recipe conflicts with the previous recipe
     Given a project directory

--- a/features/jalapenoignore.feature
+++ b/features/jalapenoignore.feature
@@ -11,7 +11,7 @@ Feature: Jalapenoignore
     And no errors were printed
     When I change recipe "foo" to version "v0.0.2"
     And I change project file "README.md" to contain "bar"
-    And I upgrade recipe "foo"
+    And I upgrade sauce "foo"
     Then the project directory should contain file "README.md" with "bar"
     And no errors were printed
     And no conflicts were reported
@@ -24,7 +24,7 @@ Feature: Jalapenoignore
     And I change project file "README.md" to contain "bar"
     And I change recipe "foo" to version "v0.0.2"
     And I change project file ".jalapenoignore" to contain "*.md"
-    And I upgrade recipe "foo"
+    And I upgrade sauce "foo"
     Then the project directory should contain file "README.md" with "bar"
     And no errors were printed
     And no conflicts were reported

--- a/features/upgrade-recipe.feature
+++ b/features/upgrade-recipe.feature
@@ -9,7 +9,7 @@ Feature: Upgrade sauce
     And I change recipe "foo" to version "v0.0.2"
     And I change recipe "foo" template "README.md" to render "New version"
     When I upgrade sauce "foo"
-    Then the project directory should contain file ".jalapeno/sauce.yml" with "version: v0.0.2"
+    Then the project directory should contain file ".jalapeno/sauces.yml" with "version: v0.0.2"
     And no errors were printed
     And the project directory should contain file "README.md" with "New version"
     And no conflicts were reported

--- a/features/upgrade-recipe.feature
+++ b/features/upgrade-recipe.feature
@@ -1,15 +1,15 @@
-Feature: Upgrade recipe
-  Upgrade a rendered Jalapeno recipe
+Feature: Upgrade sauce
+  Upgrade a Jalapeno sauce
 
-  Scenario: Upgrade rendered recipe
+  Scenario: Upgrade sauce
     Given a project directory
     And a recipes directory
     And a recipe "foo" that generates file "README.md"
     And I execute recipe "foo"
     And I change recipe "foo" to version "v0.0.2"
     And I change recipe "foo" template "README.md" to render "New version"
-    When I upgrade recipe "foo"
-    Then the project directory should contain file ".jalapeno/recipe.yml" with "version: v0.0.2"
+    When I upgrade sauce "foo"
+    Then the project directory should contain file ".jalapeno/sauce.yml" with "version: v0.0.2"
     And no errors were printed
     And the project directory should contain file "README.md" with "New version"
     And no conflicts were reported
@@ -22,6 +22,6 @@ Feature: Upgrade recipe
     And I change recipe "foo" to version "v0.0.2"
     And I change recipe "foo" template "README.md" to render "New version"
     And I change project file "README.md" to contain "Locally modified"
-    When I upgrade recipe "foo"
+    When I upgrade sauce "foo"
     Then conflicts are reported
     And the project directory should contain file "README.md" with "Locally modified"

--- a/pkg/recipe/loader.go
+++ b/pkg/recipe/loader.go
@@ -1,10 +1,7 @@
 package recipe
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,12 +14,11 @@ const (
 	RecipeFileName         = "recipe"
 	RecipeTemplatesDirName = "templates"
 	RecipeTestsDirName     = "tests"
-	RenderedRecipeDirName  = ".jalapeno"
 	IgnoreFileName         = ".jalapenoignore"
 )
 
-// Load a recipe from a path. The function does validate the recipe before returning it
-func Load(path string) (*Recipe, error) {
+// LoadRecipe a recipe from a path. The function does validate the recipe before returning it
+func LoadRecipe(path string) (*Recipe, error) {
 	rootDir, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
@@ -34,7 +30,7 @@ func Load(path string) (*Recipe, error) {
 		return nil, err
 	}
 
-	recipe := New()
+	recipe := NewRecipe()
 	err = yaml.Unmarshal(dat, recipe)
 	if err != nil {
 		return nil, err
@@ -55,54 +51,6 @@ func Load(path string) (*Recipe, error) {
 	}
 
 	return recipe, nil
-}
-
-// Load recipes which already have been rendered. Always loads
-// all recipes.
-func LoadRendered(projectDir string) ([]*Recipe, error) {
-	var recipes []*Recipe
-
-	recipeFile := filepath.Join(projectDir, RenderedRecipeDirName, RecipeFileName+YAMLExtension)
-	if _, err := os.Stat(recipeFile); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// treat missing file as empty
-			return recipes, nil
-		}
-		// other errors go boom in os.ReadFile() below
-	}
-	recipedata, err := os.ReadFile(recipeFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read recipe file: %w", err)
-	}
-
-	decoder := yaml.NewDecoder(bytes.NewReader(recipedata))
-	for {
-		recipe := New()
-		if err := decoder.Decode(&recipe); err != nil {
-			if err != io.EOF {
-				return nil, fmt.Errorf("failed to decode recipe: %w", err)
-			}
-			// ran out of recipe file, all yaml documents read
-			break
-		}
-		// read rendered files
-		for path, file := range recipe.Files {
-			data, err := os.ReadFile(filepath.Join(projectDir, path))
-			if err != nil {
-				return nil, fmt.Errorf("failed to read rendered file: %w", err)
-			}
-			file.Content = data
-			recipe.Files[path] = file
-		}
-
-		if err := recipe.Validate(); err != nil {
-			return nil, fmt.Errorf("failed to validate recipe: %w", err)
-		}
-
-		recipes = append(recipes, recipe)
-	}
-
-	return recipes, nil
 }
 
 func loadTemplates(recipePath string) (map[string][]byte, error) {

--- a/pkg/recipe/loader_test.go
+++ b/pkg/recipe/loader_test.go
@@ -14,12 +14,12 @@ func TestLoadNoRenderedRecipes(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	sauce, err := LoadSauce(dir)
+	sauces, err := LoadSauces(dir)
 	if err != nil {
 		t.Fatalf("unexpected error when loading from empty dir: %s", err)
 	}
-	if len(sauce) != 0 {
-		t.Fatalf("expected slice of length 0, got %d", len(sauce))
+	if len(sauces) != 0 {
+		t.Fatalf("expected slice of length 0, got %d", len(sauces))
 	}
 }
 
@@ -60,23 +60,23 @@ files:
     checksum: sha256:1b42293a96dbdcf36ee77dcbee6e2e2804ab085d32e6a2de7736198a0d111044
 `
 
-	if err = os.WriteFile(filepath.Join(dir, SauceDirName, SauceFileName+YAMLExtension), []byte(sauces), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(dir, SauceDirName, SaucesFileName+YAMLExtension), []byte(sauces), 0644); err != nil {
 		t.Fatalf("cannot write recipe metadata file: %s", err)
 	}
 
-	sauce, err := LoadSauce(dir)
+	loadedSauces, err := LoadSauces(dir)
 	if err != nil {
 		t.Fatalf("failed to load recipes: %s", err)
 	}
-	if len(sauce) != 2 {
-		t.Fatalf("expected to load 2 recipes, loaded %d", len(sauce))
+	if len(loadedSauces) != 2 {
+		t.Fatalf("expected to load 2 recipes, loaded %d", len(loadedSauces))
 	}
 
-	if sauce[0].Recipe.Name != "foo" {
-		t.Fatalf("expected 'foo' as the first recipe name, got %s", sauce[0].Recipe.Name)
+	if loadedSauces[0].Recipe.Name != "foo" {
+		t.Fatalf("expected 'foo' as the first recipe name, got %s", loadedSauces[0].Recipe.Name)
 	}
-	if sauce[1].Recipe.Name != "bar" {
-		t.Fatalf("expected 'bar' as the first recipe name, got %s", sauce[0].Recipe.Name)
+	if loadedSauces[1].Recipe.Name != "bar" {
+		t.Fatalf("expected 'bar' as the first recipe name, got %s", loadedSauces[0].Recipe.Name)
 	}
 }
 

--- a/pkg/recipe/loader_test.go
+++ b/pkg/recipe/loader_test.go
@@ -14,12 +14,12 @@ func TestLoadNoRenderedRecipes(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	loaded, err := LoadRendered(dir)
+	sauce, err := LoadSauce(dir)
 	if err != nil {
 		t.Fatalf("unexpected error when loading from empty dir: %s", err)
 	}
-	if len(loaded) != 0 {
-		t.Fatalf("expected slice of length 0, got %d", len(loaded))
+	if len(sauce) != 0 {
+		t.Fatalf("expected slice of length 0, got %d", len(sauce))
 	}
 }
 
@@ -30,7 +30,7 @@ func TestLoadMultipleRenderedRecipes(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	if err = os.MkdirAll(filepath.Join(dir, RenderedRecipeDirName), 0755); err != nil {
+	if err = os.MkdirAll(filepath.Join(dir, SauceDirName), 0755); err != nil {
 		t.Fatalf("cannot create metadata dir: %s", err)
 	}
 
@@ -42,7 +42,8 @@ func TestLoadMultipleRenderedRecipes(t *testing.T) {
 		t.Fatalf("cannot write rendered template: %s", err)
 	}
 
-	recipes := `apiVersion: v1
+	sauces := `
+apiVersion: v1
 name: foo
 version: v1.0.0
 description: foo recipe
@@ -59,23 +60,23 @@ files:
     checksum: sha256:1b42293a96dbdcf36ee77dcbee6e2e2804ab085d32e6a2de7736198a0d111044
 `
 
-	if err = os.WriteFile(filepath.Join(dir, RenderedRecipeDirName, RecipeFileName+YAMLExtension), []byte(recipes), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(dir, SauceDirName, SauceFileName+YAMLExtension), []byte(sauces), 0644); err != nil {
 		t.Fatalf("cannot write recipe metadata file: %s", err)
 	}
 
-	loaded, err := LoadRendered(dir)
+	sauce, err := LoadSauce(dir)
 	if err != nil {
 		t.Fatalf("failed to load recipes: %s", err)
 	}
-	if len(loaded) != 2 {
-		t.Fatalf("expected to load 2 recipes, loaded %d", len(loaded))
+	if len(sauce) != 2 {
+		t.Fatalf("expected to load 2 recipes, loaded %d", len(sauce))
 	}
 
-	if loaded[0].Name != "foo" {
-		t.Fatalf("expected 'foo' as the first recipe name, got %s", loaded[0].Name)
+	if sauce[0].Recipe.Name != "foo" {
+		t.Fatalf("expected 'foo' as the first recipe name, got %s", sauce[0].Recipe.Name)
 	}
-	if loaded[1].Name != "bar" {
-		t.Fatalf("expected 'bar' as the first recipe name, got %s", loaded[0].Name)
+	if sauce[1].Recipe.Name != "bar" {
+		t.Fatalf("expected 'bar' as the first recipe name, got %s", sauce[0].Recipe.Name)
 	}
 }
 
@@ -117,7 +118,7 @@ files:
 		t.Fatalf("cannot write recipe test file: %s", err)
 	}
 
-	loaded, err := Load(dir)
+	loaded, err := LoadRecipe(dir)
 	if err != nil {
 		t.Fatalf("failed to load the recipe: %s", err)
 	}

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -39,6 +39,10 @@ func (m *Metadata) Validate() error {
 		return fmt.Errorf("unreconized metadata API version \"%s\"", m.APIVersion)
 	}
 
+	if m.Name == "" {
+		return fmt.Errorf("recipe name can not be empty")
+	}
+
 	if !semver.IsValid(m.Version) {
 		return fmt.Errorf("version \"%s\" is not a valid semver", m.Version)
 	}

--- a/pkg/recipe/recipe.go
+++ b/pkg/recipe/recipe.go
@@ -34,10 +34,6 @@ func (re *Recipe) Validate() error {
 		return err
 	}
 
-	if len(re.Templates) == 0 {
-		return errors.New("the recipe does not contain any templates")
-	}
-
 	checkDuplicates := make(map[string]bool)
 	for _, v := range re.Variables {
 		if err := v.Validate(); err != nil {
@@ -120,9 +116,4 @@ func (s *Sauce) Conflicts(other *Sauce) []RecipeConflict {
 		}
 	}
 	return conflicts
-}
-
-// Check if the recipe conflicts with another recipe. Recipes conflict if they touch the same files.
-func (re *Recipe) Test() error {
-	return nil
 }

--- a/pkg/recipe/recipe.go
+++ b/pkg/recipe/recipe.go
@@ -8,16 +8,9 @@ import (
 	"github.com/futurice/jalapeno/pkg/engine"
 )
 
-type File struct {
-	Checksum string `yaml:"checksum"` // e.g. "sha256:asdjfajdfa" w. default algo
-	Content  []byte `yaml:"-"`
-}
-
 type Recipe struct {
 	Metadata  `yaml:",inline"`
 	Variables []Variable        `yaml:"vars,omitempty"`
-	Values    VariableValues    `yaml:"values,omitempty"`
-	Files     map[string]File   `yaml:"files,omitempty"`
 	Templates map[string][]byte `yaml:"-"`
 	Tests     []Test            `yaml:"-"`
 	engine    RenderEngine
@@ -27,8 +20,11 @@ type RenderEngine interface {
 	Render(templates map[string][]byte, values map[string]interface{}) (map[string][]byte, error)
 }
 
-func New() *Recipe {
+func NewRecipe() *Recipe {
 	return &Recipe{
+		Metadata: Metadata{
+			APIVersion: "v1",
+		},
 		engine: engine.Engine{},
 	}
 }
@@ -38,8 +34,8 @@ func (re *Recipe) Validate() error {
 		return err
 	}
 
-	if len(re.Templates) == 0 && len(re.Files) == 0 {
-		return errors.New("the recipe does not contain any templates or rendered files")
+	if len(re.Templates) == 0 {
+		return errors.New("the recipe does not contain any templates")
 	}
 
 	checkDuplicates := make(map[string]bool)
@@ -67,40 +63,40 @@ func (re *Recipe) SetEngine(e RenderEngine) {
 }
 
 // Renders recipe templates from .Templates to .Files
-func (re *Recipe) Render() error {
+func (re *Recipe) Execute(values VariableValues) (*Sauce, error) {
 	if re.engine == nil {
-		return errors.New("render engine has not been set")
+		return nil, errors.New("render engine has not been set")
 	}
 
 	// Define the context which is available on templates
 	context := map[string]interface{}{
 		"Recipe":    re.Metadata,
-		"Variables": re.Values,
+		"Variables": values,
 	}
 
 	var err error
 	files, err := re.engine.Render(re.Templates, context)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	re.Files = make(map[string]File, len(files))
+	sauce := &Sauce{
+		Recipe: *re,
+		Values: values,
+	}
+
+	sauce.Files = make(map[string]File, len(files))
 	idx := 0
 	for filename, content := range files {
 		sum := sha256.Sum256(content)
-		re.Files[filename] = File{Content: content, Checksum: fmt.Sprintf("sha256:%x", sum)}
+		sauce.Files[filename] = File{Content: content, Checksum: fmt.Sprintf("sha256:%x", sum)}
 		idx += 1
 		if idx > len(files) {
-			return errors.New("files array grew during execution")
+			return nil, errors.New("files array grew during execution")
 		}
 	}
 
-	return nil
-}
-
-// Check if the recipe is in executed state (the templates has been rendered)
-func (re *Recipe) IsExecuted() bool {
-	return len(re.Files) > 0
+	return sauce, nil
 }
 
 type RecipeConflict struct {
@@ -110,9 +106,9 @@ type RecipeConflict struct {
 }
 
 // Check if the recipe conflicts with another recipe. Recipes conflict if they touch the same files.
-func (re *Recipe) Conflicts(other *Recipe) []RecipeConflict {
+func (s *Sauce) Conflicts(other *Sauce) []RecipeConflict {
 	var conflicts []RecipeConflict
-	for path, file := range re.Files {
+	for path, file := range s.Files {
 		if otherFile, exists := other.Files[path]; exists {
 			conflicts = append(
 				conflicts,

--- a/pkg/recipe/recipe_test.go
+++ b/pkg/recipe/recipe_test.go
@@ -42,7 +42,6 @@ func TestRecipeRenderChecksums(t *testing.T) {
 				Name: "foo",
 			},
 		},
-		Values: VariableValues{"foo": "bar"},
 		Templates: map[string][]byte{
 			"README.md": []byte("{{ .Variables.foo }}"),
 		},
@@ -50,11 +49,12 @@ func TestRecipeRenderChecksums(t *testing.T) {
 
 	recipe.SetEngine(TestRenderEngine{})
 
-	if err := recipe.Render(); err != nil {
+	sauce, err := recipe.Execute(VariableValues{"foo": "bar"})
+	if err != nil {
 		t.Fatalf("Failed to render recipe: %s", err)
 	}
 
-	readme := recipe.Files["README.md"]
+	readme := sauce.Files["README.md"]
 	sumWithAlgo := "sha256:fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
 	if readme.Checksum != sumWithAlgo {
 		t.Fatalf("Expected checksum %s for content %s to match %s", readme.Content, readme.Checksum, sumWithAlgo)

--- a/pkg/recipe/sauce.go
+++ b/pkg/recipe/sauce.go
@@ -24,7 +24,7 @@ type Sauce struct {
 }
 
 const (
-	SauceFileName = "sauce"
+	SauceFileName = "sauces"
 	SauceDirName  = ".jalapeno"
 )
 

--- a/pkg/recipe/sauce.go
+++ b/pkg/recipe/sauce.go
@@ -1,0 +1,85 @@
+package recipe
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/go-yaml/yaml"
+)
+
+type File struct {
+	Checksum string `yaml:"checksum"` // e.g. "sha256:asdjfajdfa" w. default algo
+	Content  []byte `yaml:"-"`
+}
+
+// Sauce represents a rendered recipe
+type Sauce struct {
+	Recipe Recipe          `yaml:",inline"`
+	Values VariableValues  `yaml:"values,omitempty"`
+	Files  map[string]File `yaml:"files"`
+}
+
+const (
+	SauceFileName = "sauce"
+	SauceDirName  = ".jalapeno"
+)
+
+func NewSauce() *Sauce {
+	return &Sauce{}
+}
+
+func (s *Sauce) Validate() error {
+	// TODO
+	return nil
+}
+
+// Load all sauces from a project directory
+func LoadSauce(projectDir string) ([]*Sauce, error) {
+	var sauces []*Sauce
+
+	sauceFile := filepath.Join(projectDir, SauceDirName, SauceFileName+YAMLExtension)
+	if _, err := os.Stat(sauceFile); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// treat missing file as empty
+			return sauces, nil
+		}
+		// other errors go boom in os.ReadFile() below
+	}
+	recipedata, err := os.ReadFile(sauceFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read recipe file: %w", err)
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(recipedata))
+	for {
+		sauce := NewSauce()
+		if err := decoder.Decode(&sauce); err != nil {
+			if err != io.EOF {
+				return nil, fmt.Errorf("failed to decode recipe: %w", err)
+			}
+			// ran out of recipe file, all yaml documents read
+			break
+		}
+		// read rendered files
+		for path, file := range sauce.Files {
+			data, err := os.ReadFile(filepath.Join(projectDir, path))
+			if err != nil {
+				return nil, fmt.Errorf("failed to read rendered file: %w", err)
+			}
+			file.Content = data
+			sauce.Files[path] = file
+		}
+
+		if err := sauce.Validate(); err != nil {
+			return nil, fmt.Errorf("failed to validate recipe: %w", err)
+		}
+
+		sauces = append(sauces, sauce)
+	}
+
+	return sauces, nil
+}

--- a/pkg/recipe/saver.go
+++ b/pkg/recipe/saver.go
@@ -8,16 +8,117 @@ import (
 	"github.com/go-yaml/yaml"
 )
 
-func (s *Recipe) Save(dest string) error {
-	// TODO
+const defaultFileMode os.FileMode = 0700
+
+// Save saves recipe to given destination
+func (re *Recipe) Save(dest string) error {
+	// TODO: Make sure recipe name is path friendly
+	recipeDir := filepath.Join(dest, re.Name)
+
+	// TODO: Override recipe if already exists?
+	if _, err := os.Stat(recipeDir); !os.IsNotExist(err) {
+		return fmt.Errorf("directory '%s' already exists", dest)
+	}
+
+	err := os.Mkdir(recipeDir, defaultFileMode)
+	if err != nil {
+		return fmt.Errorf("can not create directory %s: %v", recipeDir, err)
+	}
+
+	recipeFilepath := filepath.Join(recipeDir, RecipeFileName+YAMLExtension)
+	file, err := os.Create(recipeFilepath)
+	if err != nil {
+		return fmt.Errorf("failed to create recipe file: %w", err)
+	}
+
+	encoder := yaml.NewEncoder(file)
+	if err := encoder.Encode(re); err != nil {
+		return fmt.Errorf("failed to write recipe test to a file: %w", err)
+	}
+
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("failed to close recipe YAML encoder: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("failed to close recipe file: %w", err)
+	}
+
+	err = re.saveTemplates(recipeDir)
+	if err != nil {
+		return fmt.Errorf("can not save recipe templates: %w", err)
+	}
+
+	err = re.saveTests(recipeDir)
+	if err != nil {
+		return fmt.Errorf("can not save recipe tests: %w", err)
+	}
+
 	return nil
 }
 
-// Saves sauce to given destination
+func (re *Recipe) saveTests(dest string) error {
+	if len(re.Tests) == 0 {
+		return nil
+	}
+
+	testDir := filepath.Join(dest, RecipeTestsDirName)
+
+	err := os.Mkdir(testDir, defaultFileMode)
+	if err != nil {
+		return fmt.Errorf("can not create recipe test directory: %w", err)
+	}
+
+	for _, test := range re.Tests {
+		file, err := os.Create(filepath.Join(testDir, test.Name+YAMLExtension))
+		if err != nil {
+			return fmt.Errorf("failed to create rendered recipe file: %w", err)
+		}
+
+		encoder := yaml.NewEncoder(file)
+
+		if err := encoder.Encode(test); err != nil {
+			return fmt.Errorf("failed to write recipe test to a file: %w", err)
+		}
+
+		if err := encoder.Close(); err != nil {
+			return fmt.Errorf("failed to close recipe test YAML encoder: %w", err)
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("failed to close recipe test file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (re *Recipe) saveTemplates(dest string) error {
+	templateDir := filepath.Join(dest, RecipeTemplatesDirName)
+	err := os.Mkdir(templateDir, defaultFileMode)
+	if err != nil {
+		return fmt.Errorf("can not save templates to the directory: %w", err)
+	}
+
+	for relativeFilepath, content := range re.Templates {
+		templatePath := filepath.Join(templateDir, relativeFilepath)
+		err = os.MkdirAll(filepath.Dir(templatePath), defaultFileMode)
+		if err != nil {
+			return fmt.Errorf("failed to create rendered recipe file: %w", err)
+		}
+
+		err := os.WriteFile(templatePath, content, defaultFileMode)
+		if err != nil {
+			return fmt.Errorf("failed to create rendered recipe file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Save saves sauce to given destination
 func (s *Sauce) Save(dest string) error {
 	// load all sauces from target dir, because we will either replace
 	// a previous rendering of this recipe, or create a new file
-	sauces, err := LoadSauce(dest)
+	sauces, err := LoadSauces(dest)
 	if err != nil {
 		return err
 	}
@@ -35,17 +136,17 @@ func (s *Sauce) Save(dest string) error {
 		sauces = append(sauces, s)
 	}
 
-	if err := os.MkdirAll(filepath.Join(dest, SauceDirName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dest, SauceDirName), defaultFileMode); err != nil {
 		return fmt.Errorf("failed to create rendered recipe dir: %w", err)
 	}
-	file, err := os.Create(filepath.Join(dest, SauceDirName, SauceFileName+YAMLExtension))
+	file, err := os.Create(filepath.Join(dest, SauceDirName, SaucesFileName+YAMLExtension))
 	if err != nil {
 		return fmt.Errorf("failed to create rendered recipe file: %w", err)
 	}
 	encoder := yaml.NewEncoder(file)
 
-	for _, recipe := range sauces {
-		if err := encoder.Encode(recipe); err != nil {
+	for _, sauce := range sauces {
+		if err := encoder.Encode(sauce); err != nil {
 			return fmt.Errorf("failed to write recipes: %w", err)
 		}
 	}

--- a/pkg/recipe/saver.go
+++ b/pkg/recipe/saver.go
@@ -8,38 +8,43 @@ import (
 	"github.com/go-yaml/yaml"
 )
 
-// Saves recipe file to given destination
-func (re *Recipe) Save(dest string) error {
-	// load all recipes from target dir, because we will either replace
+func (s *Recipe) Save(dest string) error {
+	// TODO
+	return nil
+}
+
+// Saves sauce to given destination
+func (s *Sauce) Save(dest string) error {
+	// load all sauces from target dir, because we will either replace
 	// a previous rendering of this recipe, or create a new file
-	recipes, err := LoadRendered(dest)
+	sauces, err := LoadSauce(dest)
 	if err != nil {
 		return err
 	}
 	added := false
-	for i, prev := range recipes {
-		if re.Name == prev.Name {
+	for i, prev := range sauces {
+		if s.Recipe.Name == prev.Recipe.Name {
 			// found by name
-			recipes[i] = re
+			sauces[i] = s
 			added = true
 			break
 		}
 	}
 	if !added {
 		// we hit the end, append
-		recipes = append(recipes, re)
+		sauces = append(sauces, s)
 	}
 
-	if err := os.MkdirAll(filepath.Join(dest, RenderedRecipeDirName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dest, SauceDirName), 0755); err != nil {
 		return fmt.Errorf("failed to create rendered recipe dir: %w", err)
 	}
-	file, err := os.Create(filepath.Join(dest, RenderedRecipeDirName, RecipeFileName+YAMLExtension))
+	file, err := os.Create(filepath.Join(dest, SauceDirName, SauceFileName+YAMLExtension))
 	if err != nil {
 		return fmt.Errorf("failed to create rendered recipe file: %w", err)
 	}
 	encoder := yaml.NewEncoder(file)
 
-	for _, recipe := range recipes {
+	for _, recipe := range sauces {
 		if err := encoder.Encode(recipe); err != nil {
 			return fmt.Errorf("failed to write recipes: %w", err)
 		}

--- a/pkg/recipe/saver_test.go
+++ b/pkg/recipe/saver_test.go
@@ -1,0 +1,43 @@
+package recipe
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSaveRecipe(t *testing.T) {
+	dir, err := os.MkdirTemp("", "jalapeno-test-saver")
+	if err != nil {
+		t.Fatalf("cannot create temp dir: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	re := NewRecipe()
+	re.Name = "Test"
+	re.Version = "v0.0.1"
+	re.Templates = map[string][]byte{
+		"foo.md":         []byte("foo"),
+		"foo/bar.md":     []byte("bar"),
+		"foo/bar/baz.md": []byte("baz"),
+	}
+	re.Tests = []Test{
+		{
+			Name: "baz_test",
+			Files: map[string]TestFile{
+				"foo/bar/baz.md": []byte("baz"),
+			},
+		},
+	}
+
+	err = re.Validate()
+	if err != nil {
+		t.Fatalf("test recipe was not valid: %s", err)
+	}
+
+	err = re.Save(dir)
+	if err != nil {
+		t.Fatalf("failed to save recipe: %s", err)
+	}
+
+	// TODO: Check output files
+}

--- a/pkg/recipe/test.go
+++ b/pkg/recipe/test.go
@@ -50,20 +50,19 @@ func (t *Test) Validate() error {
 func (re *Recipe) RunTests() []error {
 	errors := make([]error, len(re.Tests))
 	for i, t := range re.Tests {
-		re.Values = t.Values
-		err := re.Render()
+		sauce, err := re.Execute(t.Values)
 		if err != nil {
 			errors[i] = fmt.Errorf("%w", err)
 		}
 
-		if len(t.Files) != len(re.Files) {
+		if len(t.Files) != len(sauce.Files) {
 			// TODO: show which files were missing/extra
 			errors[i] = ErrTestWrongFileAmount
 			continue
 		}
 
 		for key, tFile := range t.Files {
-			if file, ok := re.Files[key]; !ok {
+			if file, ok := sauce.Files[key]; !ok {
 				errors[i] = fmt.Errorf("%w: file '%s'", ErrTestMissingFile, key)
 				continue
 			} else {

--- a/pkg/recipe/test_test.go
+++ b/pkg/recipe/test_test.go
@@ -144,7 +144,7 @@ func TestRecipeTests(t *testing.T) {
 			for i, t := range scenario.tests {
 				tests[i] = t.Test
 			}
-			recipe := New()
+			recipe := NewRecipe()
 			recipe.Tests = tests
 			recipe.Templates = scenario.templates
 

--- a/pkg/recipeutil/modified.go
+++ b/pkg/recipeutil/modified.go
@@ -12,7 +12,7 @@ import (
 func IsFileModified(projectDir, path string, file recipe.File) (bool, error) {
 	content, err := os.ReadFile(filepath.Join(projectDir, path))
 	if err != nil {
-		return false, fmt.Errorf("Could not read %s in %s: %e", path, projectDir, err)
+		return false, fmt.Errorf("could not read %s in %s: %e", path, projectDir, err)
 	}
 	sum := sha256.Sum256(content)
 	return file.Checksum != fmt.Sprintf("sha256:%x", sum), nil

--- a/pkg/recipeutil/prompt.go
+++ b/pkg/recipeutil/prompt.go
@@ -7,17 +7,11 @@ import (
 	"github.com/futurice/jalapeno/pkg/recipe"
 )
 
-func PromptUserForValues(re *recipe.Recipe) error {
+func PromptUserForValues(variables []recipe.Variable) (recipe.VariableValues, error) {
 	values := recipe.VariableValues{}
 	headerAdded := false
 
-	for _, variable := range re.Variables {
-		// Check if there already exist value for the given variable
-		if value, exists := re.Values[variable.Name]; exists {
-			values[variable.Name] = value
-			continue
-		}
-
+	for _, variable := range variables {
 		if !headerAdded {
 			fmt.Println("\nProvide the following variables:")
 			headerAdded = true
@@ -60,7 +54,7 @@ func PromptUserForValues(re *recipe.Recipe) error {
 		if variable.RegExp.Pattern != "" {
 			validator, err := variable.RegExp.CreateValidatorFunc()
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			opts = append(opts, survey.WithValidator(validator))
@@ -68,14 +62,13 @@ func PromptUserForValues(re *recipe.Recipe) error {
 
 		answer, err := askFunc(prompt, opts)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		values[variable.Name] = answer
 	}
 
-	re.Values = values
-	return nil
+	return values, nil
 }
 
 // NOTE: Since survey.AskOne tries to cast the answer to the type of the response


### PR DESCRIPTION
Distinct recipe and "rendered" recipe from each other by introducing `Sauce` type, which represents the rendered recipe. This makes the code lot simpler since now `Recipe` can only be in "non-rendered" state