### PR TITLE
Template file extension

### DIFF
--- a/cmd/docs/templates/schema.tmpl
+++ b/cmd/docs/templates/schema.tmpl
@@ -8,7 +8,7 @@
 | `version` | `string` | | Version of the recipe. Must be valid [semver](https://semver.org/). |
 | `description` | `string` | | Description of what the recipe does |
 | `sources` | `[]string` | | A list of URLs to source code for this recipe. |
-| `templateExtension` | `string` | `` | Extension of files in `sources` that are considered templates and are processed with the template engine. Must start with a period if not empty. |
+| `templateExtension` | `string` | | Extension of files in `sources` that are considered templates and are processed with the template engine. Must start with a period if not empty. |
 | `initHelp` | `string` | | A message which will be showed to an user after a succesful recipe execution. Can be used to guide the user what should be done next in the project directory. |
 | `ignorePatterns` | `[]string` | | Glob patterns for ignoring generated files from future recipe upgrades. Ignored files will not be regenerated even if their templates change in future versions of the recipe. |
 | `vars` | [`[]Variable`](#variable) | | An array of variables which can be used in templates. The user will be prompted to provide the value for the variable if not predefined with `--set` flag. |

--- a/cmd/docs/templates/schema.tmpl
+++ b/cmd/docs/templates/schema.tmpl
@@ -8,6 +8,7 @@
 | `version` | `string` | | Version of the recipe. Must be valid [semver](https://semver.org/). |
 | `description` | `string` | | Description of what the recipe does |
 | `sources` | `[]string` | | A list of URLs to source code for this recipe. |
+| `templateExtension` | `string` | `` | Extension of files in `sources` that are considered templates and are processed with the template engine. Must start with a period if not empty. |
 | `initHelp` | `string` | | A message which will be showed to an user after a succesful recipe execution. Can be used to guide the user what should be done next in the project directory. |
 | `ignorePatterns` | `[]string` | | Glob patterns for ignoring generated files from future recipe upgrades. Ignored files will not be regenerated even if their templates change in future versions of the recipe. |
 | `vars` | [`[]Variable`](#variable) | | An array of variables which can be used in templates. The user will be prompted to provide the value for the variable if not predefined with `--set` flag. |

--- a/internal/cli/execute.go
+++ b/internal/cli/execute.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/futurice/jalapeno/internal/cli/option"
+	"github.com/futurice/jalapeno/pkg/engine"
 	"github.com/futurice/jalapeno/pkg/oci"
 	"github.com/futurice/jalapeno/pkg/recipe"
 	"github.com/futurice/jalapeno/pkg/recipeutil"
@@ -156,7 +157,7 @@ func runExecute(cmd *cobra.Command, opts executeOptions) error {
 		values = recipeutil.MergeValues(values, promptedValues)
 	}
 
-	sauce, err := re.Execute(values, uuid.Must(uuid.NewV4()))
+	sauce, err := re.Execute(engine.Engine{}, values, uuid.Must(uuid.NewV4()))
 	if err != nil {
 		return err
 	}

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/futurice/jalapeno/internal/cli/option"
+	"github.com/futurice/jalapeno/pkg/engine"
 	"github.com/futurice/jalapeno/pkg/recipe"
 	"github.com/futurice/jalapeno/pkg/recipeutil"
 	"github.com/spf13/cobra"
@@ -83,7 +84,7 @@ func runTest(cmd *cobra.Command, opts testOptions) error {
 	if opts.UpdateSnapshots {
 		for i := range re.Tests {
 			test := &re.Tests[i]
-			sauce, err := re.Execute(test.Values, recipe.TestID)
+			sauce, err := re.Execute(engine.Engine{}, test.Values, recipe.TestID)
 			if err != nil {
 				return fmt.Errorf("failed to render templates: %w", err)
 			}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/futurice/jalapeno/internal/cli/option"
+	"github.com/futurice/jalapeno/pkg/engine"
 	"github.com/futurice/jalapeno/pkg/oci"
 	"github.com/futurice/jalapeno/pkg/recipe"
 	"github.com/futurice/jalapeno/pkg/recipeutil"
@@ -191,7 +192,7 @@ func runUpgrade(cmd *cobra.Command, opts upgradeOptions) error {
 		values = recipeutil.MergeValues(values, promptedValues)
 	}
 
-	newSauce, err := re.Execute(values, oldSauce.ID)
+	newSauce, err := re.Execute(engine.Engine{}, values, oldSauce.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/recipe/execute.go
+++ b/pkg/recipe/execute.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/gofrs/uuid"
@@ -31,12 +32,27 @@ func (re *Recipe) Execute(engine RenderEngine, values VariableValues, id uuid.UU
 		"Variables": values,
 	}
 
-	files, err := engine.Render(re.Templates, context)
+	// Filter out templates we might not want to render
+	templates := make(map[string][]byte)
+	plainFiles := make(map[string][]byte)
+	for filename, content := range re.Templates {
+		if strings.HasSuffix(filename, re.TemplateExtension) {
+			templates[filename] = content
+		} else {
+			plainFiles[filename] = content
+		}
+	}
+
+	files, err := engine.Render(templates, context)
 	if err != nil {
 		return nil, err
 	}
 
-	sauce.Files = make(map[string]File, len(files))
+	// Add the plain files
+	maps.Copy(files, plainFiles)
+
+	sauce.Files = make(map[string]File, len(re.Templates))
+
 	idx := 0
 	for filename, content := range files {
 		// Skip empty files
@@ -48,6 +64,8 @@ func (re *Recipe) Execute(engine RenderEngine, values VariableValues, id uuid.UU
 		if strings.HasPrefix(filename, "_") {
 			continue
 		}
+
+		filename = strings.TrimSuffix(filename, re.TemplateExtension)
 
 		sum := sha256.Sum256(content)
 		sauce.Files[filename] = File{Content: content, Checksum: fmt.Sprintf("sha256:%x", sum)}

--- a/pkg/recipe/execute.go
+++ b/pkg/recipe/execute.go
@@ -10,11 +10,7 @@ import (
 )
 
 // Execute executes the recipe and returns a sauce
-func (re *Recipe) Execute(values VariableValues, id uuid.UUID) (*Sauce, error) {
-	if re.engine == nil {
-		return nil, errors.New("render engine has not been set")
-	}
-
+func (re *Recipe) Execute(engine RenderEngine, values VariableValues, id uuid.UUID) (*Sauce, error) {
 	if id.IsNil() {
 		return nil, errors.New("ID was nil")
 	}
@@ -35,7 +31,7 @@ func (re *Recipe) Execute(values VariableValues, id uuid.UUID) (*Sauce, error) {
 		"Variables": values,
 	}
 
-	files, err := re.engine.Render(re.Templates, context)
+	files, err := engine.Render(re.Templates, context)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"golang.org/x/mod/semver"
 )
@@ -59,7 +60,7 @@ func (m *Metadata) Validate() error {
 		return fmt.Errorf("version \"%s\" is not a valid semver", m.Version)
 	}
 
-	if m.TemplateExtension != "" && m.TemplateExtension[0] != '.' {
+	if m.TemplateExtension != "" && !strings.HasPrefix(m.TemplateExtension, ".") {
 		return fmt.Errorf("template extension must start with a dot")
 	}
 

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -59,6 +59,10 @@ func (m *Metadata) Validate() error {
 		return fmt.Errorf("version \"%s\" is not a valid semver", m.Version)
 	}
 
+	if m.TemplateExtension != "" && m.TemplateExtension[0] != '.' {
+		return fmt.Errorf("template extension must start with a dot")
+	}
+
 	for _, sourceURL := range m.Sources {
 		if _, err := url.ParseRequestURI(sourceURL); err != nil {
 			return fmt.Errorf("source url is invalid: %w", err)

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -34,6 +34,11 @@ type Metadata struct {
 	// files will not be regenerated even if their templates change in future versions
 	// of the recipe.
 	IgnorePatterns []string `yaml:"ignorePatterns,omitempty"`
+
+	// File extension for which files in Sources should be templated. Files not matched by
+	// this extension will be copied as-is. If empty (the default) all files will be
+	// templated.
+	TemplateExtension string `yaml:"templateExtension,omitempty"`
 }
 
 func (m *Metadata) Validate() error {

--- a/pkg/recipe/recipe.go
+++ b/pkg/recipe/recipe.go
@@ -2,8 +2,6 @@ package recipe
 
 import (
 	"fmt"
-
-	"github.com/futurice/jalapeno/pkg/engine"
 )
 
 type Recipe struct {
@@ -11,7 +9,6 @@ type Recipe struct {
 	Variables []Variable        `yaml:"vars,omitempty"`
 	Templates map[string][]byte `yaml:"-"`
 	Tests     []Test            `yaml:"-"`
-	engine    RenderEngine
 }
 
 type RenderEngine interface {
@@ -23,7 +20,6 @@ func NewRecipe() *Recipe {
 		Metadata: Metadata{
 			APIVersion: "v1",
 		},
-		engine: engine.Engine{},
 	}
 }
 
@@ -50,8 +46,4 @@ func (re *Recipe) Validate() error {
 	}
 
 	return nil
-}
-
-func (re *Recipe) SetEngine(e RenderEngine) {
-	re.engine = e
 }

--- a/pkg/recipe/saver_test.go
+++ b/pkg/recipe/saver_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/futurice/jalapeno/pkg/engine"
 	"github.com/gofrs/uuid"
 )
 
@@ -92,7 +93,7 @@ func TestSaveSauce(t *testing.T) {
 		t.Fatalf("test recipe was not valid: %s", err)
 	}
 
-	sauce, err := re.Execute(nil, uuid.Must(uuid.NewV4()))
+	sauce, err := re.Execute(engine.Engine{}, nil, uuid.Must(uuid.NewV4()))
 	if err != nil {
 		t.Fatalf("recipe execution failed: %s", err)
 	}

--- a/pkg/recipe/test.go
+++ b/pkg/recipe/test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/futurice/jalapeno/pkg/engine"
 	"github.com/gofrs/uuid"
 )
 
@@ -43,7 +44,7 @@ func (t *Test) Validate() error {
 func (re *Recipe) RunTests() []error {
 	errors := make([]error, len(re.Tests))
 	for i, t := range re.Tests {
-		sauce, err := re.Execute(t.Values, TestID)
+		sauce, err := re.Execute(engine.Engine{}, t.Values, TestID)
 		if err != nil {
 			errors[i] = fmt.Errorf("%w", err)
 			continue


### PR DESCRIPTION
This PR changes template rendering such that only template files that end in ".tmpl" get run through the template engine. Other files in the templates directory get rendered as-is.

Not sure if it would be worth it to also rename the "templates" directory to something else since it will now also contain non-templated things?

Closes #39.