### PR TITLE
Homebrew tap for jalapeno

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,25 +1,50 @@
-build:
-  dir: cmd/jalapeno
-  env:
-    - CGO_ENABLED=0
-  goos:
-    - linux
-    - windows
-    - darwin
-  goarch:
-    - amd64
-    - arm64
+builds:
+  - id: jalapeno
+    dir: cmd/jalapeno
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
 archives:
-  - id: archives
-    format: binary
+  - id: jalapeno
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
 checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"
+
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+
 changelog:
   sort: asc
   filters:
     exclude:
       - "^docs:"
       - "^test:"
+
+brews:
+  - name: jalapeno
+    # GitHub repository
+    tap:
+      owner: futurice
+      name: homebrew-jalapeno
+      token: "{{ .Env.GITHUB_TOKEN_FOR_HOMEBREW_TAP }}"
+    # metadata
+    homepage: "https://futurice.github.io/jalapeno/"
+    description: "Jalapeno is a CLI for creating, managing and sharing spiced up project templates"
+    license: "Apache-2.0"
+    # how release is being downloaded/used
+    download_strategy: CurlDownloadStrategy
+    # actual formula things
+    commit_msg_template: "Brew formula update for jalapeno version {{ .Tag }}"
+    test: |
+      system "#{bin}/jalapeno --version"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,10 +34,12 @@ changelog:
 brews:
   - name: jalapeno
     # GitHub repository
-    tap:
+    repository:
       owner: futurice
       name: homebrew-jalapeno
-      token: "{{ .Env.GITHUB_TOKEN_FOR_HOMEBREW_TAP }}"
+      git:
+        url: "ssh://git@github.com:futurice/homebrew-jalapeno.git"
+        private_key: "{{ .Env.HOMEBREW_TAP_PRIVATE_KEY }}"
     # metadata
     homepage: "https://futurice.github.io/jalapeno/"
     description: "Jalapeno is a CLI for creating, managing and sharing spiced up project templates"

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -6,6 +6,15 @@ title: Installation
 
 # Installation
 
+## Via package managers
+
+### `homebrew` (MacOS and Linux)
+
+```bash
+brew tap futurice/jalapeno
+brew install jalapeno
+```
+
 ## From the Binary Releases
 
 Cross-platform binaries are provided with each release of Jalapeno. These can manually be
@@ -15,13 +24,15 @@ In short the process is:
 
 1. Download [the latest version of jalapeno](https://github.com/futurice/jalapeno/releases/latest)
 for your platform
-2. Make the binary executable
+2. Extract the archive
+3. Make the binary executable
 3. Rename and move the binary to proper location
 
 For example on MacOS (running on Apple Silicon) this can be done with:
 
 ```bash
-curl -L https://github.com/futurice/jalapeno/releases/latest/download/jalapeno-darwin-arm64 -o jalapeno
+curl -L https://github.com/futurice/jalapeno/releases/latest/download/jalapeno-darwin-arm64.tar.gz -o jalapeno.tar.gz
+tar -xvf jalapeno.tar.gz
 chmod +x jalapeno
 mv jalapeno /usr/local/bin/jalapeno
 ```


### PR DESCRIPTION
# This PR...

- Adds a goreleaser config section for publishing a homebrew tap
- Changed release format into `.tar.gz` and `.zip` archives, because homebrew's inbuilt download strategies do not understand downloading a binary directly from GitHub. The closest (and most commonly used one) is `CurlDownloadStrategy`, and it only supports picking a binary from a download archive

## For this to work 100 %, we need to...

- [x] Make sure that https://github.com/futurice/homebrew-jalapeno 's access rights are OK enough
- [x] Add https://github.com/futurice/homebrew-jalapeno 's deploy key with write rights into the GitHub Actions secrets of this repo

And I'll need help from @majori or @ilkka to make those happen.

## Notes

[I tested manually](https://github.com/futurice/homebrew-jalapeno/commit/eb65ac2cc043f79b4506de5b6faaf5df6a907968) that the generated formula should work. The tests wasn't 100 % complete, because the current releases are in binary format, so the download failed, but tapping into that repository seemed to work just fine.