### PR TITLE
Add tabbed codeblocks into documentation

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -6,11 +6,11 @@ title: Installation
 
 # Installation
 
-## Via package managers
+## Using a package manager
 
-### `homebrew` (MacOS and Linux)
+### Homebrew
 
-```bash
+```bash tab={"label":"Homebrew"}
 brew tap futurice/jalapeno
 brew install jalapeno
 ```
@@ -43,21 +43,15 @@ It is possible to use jalapeno via Docker without installing it locally. Jalapen
 from the GitHub Container Registry, and thus the following command on a *nix system is equivalent
 to running `jalapeno` locally:
 
-MacOS and Linux:
-
-```bash
+```bash tab={"label":"MacOS and Linux"}
 docker run -it --rm -v $(pwd):/workdir ghcr.io/futurice/jalapeno:v0.1.4
 ```
 
-Windows Command Line:
-
-```batch
+```batch tab={"label":"Windows Command Line"}
 docker run -it --rm -v %cd%:/workdir ghcr.io/futurice/jalapeno:v0.1.4
 ```
 
-PowerShell:
-
-```powershell
+```powershell tab={"label":"PowerShell"}
 docker run -it --rm -v ${PWD}:/workdir ghcr.io/futurice/jalapeno:v0.1.4
 ```
 
@@ -75,3 +69,12 @@ task build
 ```
 
 After this the binary is available on path `./bin/jalapeno`.
+
+## Updating your jalapeno version
+
+### Homebrew
+
+```bash tab={"label":"Homebrew"}
+brew update
+brew upgrade jalapeno
+```

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -22,7 +22,7 @@ downloaded and installed from [GitHub releases](https://github.com/futurice/jala
 
 In short the process is:
 
-1. Download [the latest version of jalapeno](https://github.com/futurice/jalapeno/releases/latest)
+1. Download [the latest version of Jalapeno](https://github.com/futurice/jalapeno/releases/latest)
 for your platform
 2. Extract the archive
 3. Make the binary executable
@@ -39,7 +39,7 @@ mv jalapeno /usr/local/bin/jalapeno
 
 ## Use via Docker
 
-It is possible to use jalapeno via Docker without installing it locally. Jalapeno image is available
+It is possible to use Jalapeno via Docker without installing it locally. Jalapeno image is available
 from the GitHub Container Registry, and thus the following command on a *nix system is equivalent
 to running `jalapeno` locally:
 
@@ -70,7 +70,7 @@ task build
 
 After this the binary is available on path `./bin/jalapeno`.
 
-## Updating your jalapeno version
+## Updating your Jalapeno version
 
 ### Homebrew
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -3,6 +3,7 @@
 
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const tabBlocksRemarkPlugin = require("docusaurus-remark-plugin-tab-blocks");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -41,6 +42,9 @@ const config = {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl: "https://github.com/futurice/jalapeno/tree/main/docs/",
+          remarkPlugins: [
+            tabBlocksRemarkPlugin
+          ],
         },
         blog: false,
         theme: {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,6 +13,7 @@
         "@docusaurus/theme-mermaid": "^2.4.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
+        "docusaurus-remark-plugin-tab-blocks": "^1.3.1",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -6039,6 +6040,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-remark-plugin-tab-blocks": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-remark-plugin-tab-blocks/-/docusaurus-remark-plugin-tab-blocks-1.3.1.tgz",
+      "integrity": "sha512-O2viowaAZ36WIsCMG2+kLnmKqK7R2FCrWldpB+9Pmt86O3UvL88Iu8hKppiLfVLzSgLf1TO2Zb8Lt5YPVMG9Qg==",
+      "dependencies": {
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/dom-converter": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
     "@docusaurus/theme-mermaid": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "docusaurus-remark-plugin-tab-blocks": "^1.3.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
This PR adds a helper, which transforms all adjacents codeblocks (marked with `tab`) in documentation into tabbed codeblocks. This is useful for providing multiple different technical ways for installing/using jalapeno, without causing the documentation page becoming too big.

Would this kind of doc improvement be OK?

As a side note, I also added a new updating section to the docs as well.