### PR TITLE
Use executable file extension for current OS

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,7 +27,7 @@ tasks:
     generates:
       - "bin/jalapeno"
     cmds:
-      - go build -o bin/jalapeno {{.ENTRYPOINT}}
+      - go build -o bin/jalapeno{{exeExt}} {{.ENTRYPOINT}}
 
   debug:
     desc: Starts the CLI in debug mode. After running the task, you can use for example VSCode to connect to the session


### PR DESCRIPTION
This would break cross-compilation but we don't do that anyway, so to me it feels like an appropriate solution for now.

Fixes: #28