### PR TITLE
feat: check validator is applied to a defined column

### DIFF
--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/expr-lang/expr"
@@ -120,6 +121,10 @@ func (v *Variable) Validate() error {
 		if validator.Column != "" {
 			if len(v.Columns) == 0 {
 				return fmt.Errorf("%s: validator is defined for column while the variable has not defined any", validatorIndex)
+			}
+
+			if slices.Index(v.Columns, validator.Column) == -1 {
+				return fmt.Errorf("%s: validator defined for undefined column %q", validatorIndex, validator.Column)
 			}
 
 			found := false

--- a/pkg/recipe/variable_test.go
+++ b/pkg/recipe/variable_test.go
@@ -50,6 +50,17 @@ func TestVariableValidation(t *testing.T) {
 			},
 			"`options` and `columns` properties can not be defined",
 		},
+		{
+			"validator defined for undefined column",
+			Variable{
+				Name:    "foo",
+				Columns: []string{"foo", "bar"},
+				Validators: []VariableValidator{
+					{Column: "cat", Pattern: ".*"},
+				},
+			},
+			"validator defined for undefined column \"cat\"",
+		},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
Eg. typo in a column name would make it look like a validator is used when in reality it was just silenty ignored. Check the validated column exists in the defined columns.