### PR TITLE
fix: text input width calculation

### DIFF
--- a/pkg/ui/survey/prompt/string.go
+++ b/pkg/ui/survey/prompt/string.go
@@ -31,7 +31,7 @@ func NewStringModel(v recipe.Variable, styles style.Styles) StringModel {
 	ti.Width = 30
 
 	if v.Default != "" {
-		ti.Width = len(v.Default) - 3
+		ti.Width = max(len(v.Default), ti.Width)
 		ti.SetValue(v.Default)
 	}
 
@@ -71,7 +71,7 @@ func (m StringModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
-		m.textInput.Width = msg.Width - 3
+		m.textInput.Width = msg.Width - 3 // make sure that the '> ' prefix and the input fit on the line
 	}
 
 	m.textInput, cmd = m.textInput.Update(msg)


### PR DESCRIPTION
The text input calculation was incorrectly subtracting 3 from the default values length, even though it should only be done for the whole line width on the windowSizeMsg in order to not overflow the line with '> ' + textInput. It was also overwriting the default 30 character width with the default value width, which in the case of for example 'main' default value would result in a 4 character wide input. 